### PR TITLE
Update mm3_nd2ToTIFF.py

### DIFF
--- a/mm3_nd2ToTIFF.py
+++ b/mm3_nd2ToTIFF.py
@@ -108,7 +108,7 @@ if __name__ == "__main__":
 
     # Load ND2 files into a list for processing
     if len(external_directory) > 0:
-        nd2files = os.path.join(glob.glob(external_directory, "*.nd2"))
+        nd2files = glob.glob(os.path.join(external_directory, "*.nd2"))
         information("Found %d files to analyze from external file." % len(nd2files))
     else:
         print("external directory: {:s}".format(p['experiment_directory']))


### PR DESCRIPTION
Line 111, correct the order of os.path.join and glob.glob when using -x option for external source of nd2 directory