### PR TITLE
Update mm3_MovieMaker.py to fix dimension mismatch after changing size to even numbers

### DIFF
--- a/mm3_MovieMaker.py
+++ b/mm3_MovieMaker.py
@@ -272,7 +272,6 @@ if __name__ == "__main__":
         size_x, size_y = image.shape[-1], image.shape[-2]
         size_x = (size_x / 2) * 2 # fixes bug if images don't have even dimensions with ffmpeg
         size_y = (size_y / 2) * 2
-        image = image[:, :size_y, :size_x] # I don't think this does anything.
 
         # set command to give to ffmpeg
         command = [FFMPEG_BIN,
@@ -310,7 +309,8 @@ if __name__ == "__main__":
                 continue
 
             image_data = tiff.imread(img) # get the image
-
+            image_data = image_data[:, :size_y, :size_x] # Adjust image_data dimension to have even numbers as size_y, size_x
+            
             # make phase stack
             if show_phase:
                 if len(image_data.shape) > 2:


### PR DESCRIPTION
fixed the problem when image and timestamp have different size. This is caused because image is read again from the source tif file and change in dimension at line 275 was not effective. Moved this line instead to after image_data is read.