### PR TITLE
Fixed mm3_Compile bug for images with fewer than three imaging channels.

### DIFF
--- a/docker/mm3-py3-CST/Dockerfile
+++ b/docker/mm3-py3-CST/Dockerfile
@@ -1,0 +1,26 @@
+# Tensorflow image based on Ubuntu 16.04 with Python 3 and Jupyter
+FROM tensorflow/tensorflow:1.13.1-py3
+
+# update repositories
+RUN apt-get update && \
+    apt -y dist-upgrade
+
+# Choose locales. Set to US.
+RUN apt-get install -y locales tzdata
+RUN locale-gen en_US.UTF-8 # en_GB.UTF-8 eu_FR.UTF-8
+
+# set timezone. Set to PST.
+RUN rm -f /etc/localtime /etc/timezone && echo "tzdata tzdata/Areas select America" > myfile && echo "tzdata tzdata/Zones/America select Chicago" >> myfile && debconf-set-selections myfile && dpkg-reconfigure -f noninteractive tzdata && rm myfile
+
+# Install minimal packages
+RUN apt-get install -y sudo vim less
+# Install libraries for X11 forwarding to display when running container on Ubuntu 18.04
+RUN apt-get install -y libx11-xcb-dev
+
+# install package for mac OSX socket sharing through x11
+RUN apt-get install -y libglu1-mesa
+
+# Copy installation script with Python packages into container and execute
+COPY install_mm3_dependencies.sh /root/
+RUN /bin/bash /root/install_mm3_dependencies.sh
+RUN rm -f /root/install_mm3_dependencies.sh

--- a/docker/mm3-py3-CST/install_mm3_dependencies.sh
+++ b/docker/mm3-py3-CST/install_mm3_dependencies.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# -y means yes
+apt-get install -y python3-tk
+
+echo "Install other packages for imaging and plotting."
+apt-get install -y libreadline-dev libsqlite3-dev libbz2-dev libssl-dev
+apt-get install -y libblas-dev liblapack-dev libatlas-dev
+apt-get install -y libpng-dev libfreetype6-dev tk-dev pkg-config
+apt-get install -y ffmpeg
+
+echo "Install additional python packages with pip."
+# Note: pip softlinks to pip3
+python -m pip install scipy
+python -m pip install matplotlib
+python -m pip install seaborn
+python -m pip install Pillow
+python -m pip install scikit-image
+python -m pip install pyYAML
+python -m pip install pandas
+python -m pip install pims_nd2
+
+# python binding
+python -m pip install freetype-py
+
+# PyQt
+python -m pip install PyQt5
+sudo apt-get -y install python3-pyqt5
+sudo apt-get -y install pyqt5-dev-tools
+sudo apt-get -y install qttools5-dev-tools

--- a/docker/username_linux/Dockerfile
+++ b/docker/username_linux/Dockerfile
@@ -6,10 +6,10 @@ FROM local/mm3-py3:root
 
 # Add new sudo user
 # Edit these
-ENV USERNAME _USERNAME_
-ENV USERID _USERID_
-ENV GROUPNAME _GROUPNAME_
-ENV GROUPID _GROUPID_
+ENV USERNAME wanglab
+ENV USERID 1000
+ENV GROUPNAME wanglab
+ENV GROUPID 1000
 
 # Don't edit this, it uses the variables above
 RUN useradd -N -m $USERNAME --uid $USERID --gid $GROUPID && \
@@ -20,5 +20,5 @@ RUN useradd -N -m $USERNAME --uid $USERID --gid $GROUPID && \
     chmod 0440 /etc/sudoers.d/$USERNAME
 
 # Edit these
-USER _USERNAME_
-WORKDIR /home/_USERNAME_
+USER wanglab
+WORKDIR /home/wanglab/sandbox

--- a/docs/Setting-up-docker.md
+++ b/docs/Setting-up-docker.md
@@ -107,7 +107,7 @@ Because we are using TensorFlow, we will build upon the official [TensorFlow ima
 
 #### 2.2.1. Edit the pre-made Dockerfiles
 
-Enter the `mm3/docker/mm3-py3/` director. This directory contains two files, a Dockerfile and an additional file named `install_mm3_dependencies.sh` which contains the packages specific to mm3. You may want to edit the Dockerfile, for example, to change the time zone of the image.
+Enter the `mm3/docker/mm3-py3/` directory. This directory contains two files, a Dockerfile and an additional file named `install_mm3_dependencies.sh` which contains the packages specific to mm3. You may want to edit the Dockerfile, for example, to change the time zone of the image.
 
 _Feel free to copy and edit the mm3/docker/ directory and run the following commands on your edited version. However, avoid uploading personal changes to the Dockerfiles to the mm3 repository._
 

--- a/mm3_ChannelPicker.py
+++ b/mm3_ChannelPicker.py
@@ -662,6 +662,7 @@ if __name__ == "__main__":
     ### Cross correlations ########################################################################
     if do_CNN:
         # a nested dict to hold predictions per channel per fov.
+        crosscorrs = None
         predictionDict = {}
 
         mm3.information('Loading model ....')

--- a/mm3_Compile.py
+++ b/mm3_Compile.py
@@ -131,7 +131,7 @@ if __name__ == "__main__":
         found_files = sorted(found_files) # should sort by timepoint
 
         # keep images starting at this timepoint
-        if t_start:
+        if t_start is not None:
             mm3.information('Removing images before time {}'.format(t_start))
             # go through list and find first place where timepoint is equivalent to t_start
             for n, ifile in enumerate(found_files):
@@ -139,11 +139,11 @@ if __name__ == "__main__":
                 # if re.search == True then a match was found
                 if re.search(string, ifile):
                     # cut off every file name prior to this one and quit the loop
-                    found_file = found_files[n:]
+                    found_files = found_files[n:]
                     break
 
         # remove images after this timepoint
-        if t_end:
+        if t_end is not None:
             mm3.information('Removing images after time {}'.format(t_end))
             # go through list and find first place where timepoint is equivalent to t_end
             for n, ifile in enumerate(found_files):
@@ -190,7 +190,7 @@ if __name__ == "__main__":
             pool.close() # tells the process nothing more will be added.
             pool.join() # blocks script until everything has been processed and workers exit
 
-            mm3.information('Image analyses pool finished, getting results.')
+            mm3.information('Image analysis pool finished, getting results.')
 
             # get results from the pool and put them in a dictionary
             for fn in analyzed_imgs.keys():
@@ -218,7 +218,7 @@ if __name__ == "__main__":
             mm3.information("Model loaded.")
 
             # initialize pool for getting image metadata
-            #pool = Pool(p['num_analyzers'])
+            pool = Pool(p['num_analyzers'])
 
             # loop over images and get information
             for fn in found_files:
@@ -226,29 +226,28 @@ if __name__ == "__main__":
                 # for each file name. Won't look for channels, just gets the metadata for later use by Unet
 
                 # This is the non-parallelized version (useful for debug)
-                analyzed_imgs[fn] = mm3.get_initial_tif_params(fn)
+                # analyzed_imgs[fn] = mm3.get_initial_tif_params(fn)
 
                 # Parallelized
-                #analyzed_imgs[fn] = pool.apply_async(mm3.get_initial_tif_params, args=(fn))
+                analyzed_imgs[fn] = pool.apply_async(mm3.get_initial_tif_params, args=(fn,))
 
             mm3.information('Waiting for image metadata pool to be finished.')
-            #print(analyzed_imgs) # uncomment for debug
-            #pool.close() # tells the process nothing more will be added.
-            #pool.join() # blocks script until everything has been processed and workers exit
+            pool.close() # tells the process nothing more will be added.
+            pool.join() # blocks script until everything has been processed and workers exit
 
             mm3.information('Image metadata pool finished, getting results.')
 
             # get results from the pool and put them in a dictionary
+            for fn in analyzed_imgs.keys():
+               result = analyzed_imgs[fn]
+               if result.successful():
+                   analyzed_imgs[fn] = result.get() # put the metadata in the dict if it's good
+               else:
+                   analyzed_imgs[fn] = False # put a false there if it's bad
 
-            #for fn in analyzed_imgs.keys():
-            #    result = analyzed_imgs[fn]
-            #    if result.successful():
-            #        analyzed_imgs[fn] = result.get() # put the metadata in the dict if it's good
-            #    else:
-            #        analyzed_imgs[fn] = False # put a false there if it's bad
+            # print(analyzed_imgs)
 
             # set up some variables for Unet and image aligment/cropping
-
             file_names = [key for key in analyzed_imgs.keys()]
             file_names.sort() # sort the file names by time
             file_names = np.asarray(file_names)
@@ -286,11 +285,12 @@ if __name__ == "__main__":
                 # get prediction of where traps are located in first image
                 imgPath = os.path.join(p['experiment_directory'], p['image_directory'],
                                        trap_align_metadata['first_frame_name'])
-                img = io.imread(imgPath)[:,:,trap_align_metadata['phase_plane_index']]
-                # print(img.shape)
+                img = io.imread(imgPath)
+                # detect if there are multiple imaging channels, and rearrange image if necessary, keeping only the phase image
+                img = mm3.permute_image(img, trap_align_metadata)
 
                 # produces predition stack with 3 "pages", index 0 is for traps, index 1 is for central tough, index 2 is for background
-                print("Predicting trap locations for first frame.")
+                mm3.information("Predicting trap locations for first frame.")
                 first_frame_trap_prediction = mm3.get_frame_predictions(img, model, stack_weights, trap_align_metadata['shift_distance'], subImageNumber=16, padSubImageNumber=25)
 
                 # flatten prediction stack such that each pixel of the resulting 2D image is the index of the prediction image above with the highest predicted probability
@@ -369,7 +369,8 @@ if __name__ == "__main__":
                 for frame,fn in enumerate(fov_file_names):
                     imgPath = os.path.join(p['experiment_directory'],p['image_directory'],fn)
                     frame_img = io.imread(imgPath)
-                    frame_img = frame_img[:,:,trap_align_metadata['phase_plane_index']]
+                    # detect if there are multiple imaging channels, and rearrange image if necessary, keeping only the phase image
+                    frame_img = mm3.permute_image(frame_img, trap_align_metadata)
                     align_region_stack[frame,:,:,0] = frame_img[centroid[0]-256:centroid[0]+256,
                                                              centroid[1]-256:centroid[1]+256]
 
@@ -416,6 +417,7 @@ if __name__ == "__main__":
                 # allocate array to store filtered traps over time
                 align_trap_mask_stack = np.zeros(align_traps.shape)
                 for frame in range(trap_align_metadata['frame_count']):
+
                     frame_trap_labels = measure.label(align_traps[frame,:,:])
                     frame_trap_props = measure.regionprops(frame_trap_labels)
 
@@ -440,6 +442,23 @@ if __name__ == "__main__":
 
                 labelled_align_trap_mask_stack = measure.label(align_trap_mask_stack)
 
+                trapTriggered = False
+                for frame in range(trap_align_metadata['frame_count']):
+                    anyTraps = np.any(labelled_align_trap_mask_stack[frame,:,:] > 0)
+                    # if anyTraps is False, that means no traps were detected for this frame. This usuall occurs due to a bug in our imaging system,
+                    #    which can cause it to miss the occasional frame. Should be fine to snag labels from prior frame.
+                    if not anyTraps:
+                        trapTriggered = True
+                        mm3.information("Frame at index {} has no detected traps. Borrowing labels from an adjacent frame.".format(frame))
+                        if frame > 0:
+                            labelled_align_trap_mask_stack[frame,:,:] = labelled_align_trap_mask_stack[frame-1,:,:]
+                        else:
+                            labelled_align_trap_mask_stack[frame,:,:] = labelled_align_trap_mask_stack[frame+1,:,:]
+
+                if trapTriggered:
+                    repaired_align_trap_mask_stack = labelled_align_trap_mask_stack > 0
+                    labelled_align_trap_mask_stack = measure.label(repaired_align_trap_mask_stack)
+
                 align_trap_props = measure.regionprops(labelled_align_trap_mask_stack)
 
                 areas = np.array([trap.area for trap in align_trap_props])
@@ -452,6 +471,12 @@ if __name__ == "__main__":
                 if p['debug']:
                     pprint(areas)
                     print(expected_area)
+
+                    if not expected_area in areas:
+                        print("No trap has expected total area. Saving labelled masks for debugging as labelled_align_trap_mask_stack.tif")
+                        io.imsave("labelled_align_trap_mask_stack.tif", labelled_align_trap_mask_stack.astype('uint8'))
+                        io.imsave("masks.tif", align_traps.astype('uint8'))
+                        # occasionally our microscope misses an image, resulting in no traps for a single frame. This obviously messes up image alignment here....
 
                 for trap in align_trap_props:
                     if trap.area != expected_area:

--- a/mm3_TrackGUI_helpers.py
+++ b/mm3_TrackGUI_helpers.py
@@ -1,0 +1,80 @@
+#! /usr/bin/env python3
+from __future__ import print_function, division
+
+from PyQt5.QtWidgets import QApplication, QMainWindow, QGraphicsScene, QGraphicsView, QRadioButton, QButtonGroup, QVBoxLayout, QHBoxLayout, QWidget, QLabel, QAction, QDockWidget, QPushButton
+from PyQt5.QtGui import QIcon, QImage, QPainter, QPen, QPixmap, qGray, QColor
+from PyQt5.QtCore import Qt, QPoint, QRectF
+from skimage import io, img_as_ubyte, color, draw, measure
+import numpy as np
+import sys
+import re
+import os
+import yaml
+import multiprocessing
+
+def init_params(param_file_path):
+    # load all the parameters into a global dictionary
+    global params
+    with open(param_file_path, 'r') as param_file:
+        params = yaml.safe_load(param_file)
+
+    # set up how to manage cores for multiprocessing
+    params['num_analyzers'] = multiprocessing.cpu_count()
+
+    # useful folder shorthands for opening files
+    params['TIFF_dir'] = os.path.join(params['experiment_directory'], params['image_directory'])
+    params['ana_dir'] = os.path.join(params['experiment_directory'], params['analysis_directory'])
+    params['hdf5_dir'] = os.path.join(params['ana_dir'], 'hdf5')
+    params['chnl_dir'] = os.path.join(params['ana_dir'], 'channels')
+    params['empty_dir'] = os.path.join(params['ana_dir'], 'empties')
+    params['sub_dir'] = os.path.join(params['ana_dir'], 'subtracted')
+    params['seg_dir'] = os.path.join(params['ana_dir'], 'segmented')
+    params['cell_dir'] = os.path.join(params['ana_dir'], 'cell_data')
+    params['track_dir'] = os.path.join(params['ana_dir'], 'tracking')
+
+    # use jd time in image metadata to make time table. Set to false if no jd time
+    if params['TIFF_source'] == 'elements' or params['TIFF_source'] == 'nd2ToTIFF':
+        params['use_jd'] = True
+    else:
+        params['use_jd'] = False
+
+
+class Window(QMainWindow):
+
+    def __init__(self, parent=None, imgPaths=None, fov_id_list=None, training_dir=None):
+        super(Window, self).__init__(parent)
+
+        top = 400
+        left = 400
+        width = 800
+        height = 600
+
+        # icon = "icons/pain.png"
+
+        self.setWindowTitle("You got this!")
+        self.setGeometry(top,left,width,height)
+
+        scene = QGraphicsScene(self)
+        
+
+if __name__ == "__main__":
+
+    imgPaths = {1:[('/home/wanglab/sandbox/trackingGUI/testset1/analysis_20190312/channels/testset1_xy001_p0033_c1.tif',
+                 '/home/wanglab/sandbox/trackingGUI/testset1/analysis_20190312/segmented/testset1_xy001_p0033_seg_unet.tif'),
+                ('/home/wanglab/sandbox/trackingGUI/testset1/analysis_20190312/channels/testset1_xy001_p0077_c1.tif',
+                 '/home/wanglab/sandbox/trackingGUI/testset1/analysis_20190312/channels/testset1_xy001_p0077_seg_unet.tif')],
+                2:[('/home/wanglab/sandbox/trackingGUI/testset1/analysis_20190312/channels/testset1_xy002_p0078_c1.tif',
+                    '/home/wanglab/sandbox/trackingGUI/testset1/analysis_20190312/segmented/testset1_xy002_p0078_seg_unet.tif'),
+                   ('/home/wanglab/sandbox/trackingGUI/testset1/analysis_20190312/channels/testset1_xy002_p0121_c1.tif',
+                    '/home/wanglab/sandbox/trackingGUI/testset1/analysis_20190312/segmented/testset1_xy002_p0121_seg_unet.tif')]}
+
+    fov_id_list = [1,2]
+
+    training_dir = '/home/wanglab/sandbox/trackingGUI'
+
+    init_params('/home/wanglab/sandbox/trackingGUI/testset1/analysis_20190312/testset1_params_20190312.yaml')
+
+    app = QApplication(sys.argv)
+    window = Window(imgPaths=imgPaths, fov_id_list=fov_id_list, training_dir=training_dir)
+    window.show()
+    app.exec_()

--- a/mm3_metamorphToTIFF.py
+++ b/mm3_metamorphToTIFF.py
@@ -111,7 +111,7 @@ if __name__ == '__main__':
         # skip if we aren't using this time point
         if (t_crop[0] and frame < t_crop[0]) or (t_crop[1] and frame > t_crop[1]):
             continue
-    
+
         new_name = os.path.join(dest_dir, '{}_t{:0=4}xy{:0=2}.tif'.format(file_prefix,
                                                                           frame,
                                                                           stagePosition))
@@ -133,6 +133,5 @@ if __name__ == '__main__':
 
         # save out image
         information("Saving {}.".format(new_name))
-        print(os.path.join(dest_dir,new_name))
+        # print(os.path.join(dest_dir,new_name))
         io.imsave(os.path.join(dest_dir, new_name), img_data)
-


### PR DESCRIPTION
When skimage.io.imread reads images with fewer than three channels, it returns numpy arrays in which the channels are separated along the 0-th axis. When I originally wrote my image cropping/alignment script, I was using solely images with three channels. I this case, skimage.io.imread returned numpy arrays in which the channels were separated on the final axis. I've written in code to handle images with fewer than three channels.